### PR TITLE
feat: implement JWT authentication and user profile retrieval ✨

### DIFF
--- a/src/adapters/api/controller/room.controller.ts
+++ b/src/adapters/api/controller/room.controller.ts
@@ -1,8 +1,11 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { CreateRoomUseCase } from '../../../core/usecases/create-room.use-case';
 import { CreateRoomRequest } from '../request/create-room.request';
 import { CreateRoomMapper } from '../mapper/create-room.mapper';
 import { GetAllRoomsUseCase } from '../../../core/usecases/get-all-rooms.use-case';
+import { CreateRoomResponse } from '../response/create-room.response';
+import { GetAllRoomsResponse } from '../response/get-all-rooms.response';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import {
   ApiBadRequestResponse,
   ApiConflictResponse,
@@ -11,10 +14,10 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { CreateRoomResponse } from '../response/create-room.response';
-import { GetAllRoomsResponse } from '../response/get-all-rooms.response';
 
+@UseGuards(JwtAuthGuard)
 @Controller('/rooms')
 export class RoomController {
   constructor(
@@ -42,6 +45,9 @@ export class RoomController {
   @ApiInternalServerErrorResponse({
     description: 'Internal server error',
   })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized access',
+  })
   async createRoom(
     @Body() body: CreateRoomRequest,
   ): Promise<CreateRoomResponse> {
@@ -58,6 +64,9 @@ export class RoomController {
   })
   @ApiInternalServerErrorResponse({
     description: 'Internal server error',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized access',
   })
   async getAllRooms(): Promise<GetAllRoomsResponse> {
     const rooms = await this.getAllRoomsUseCase.execute();

--- a/src/adapters/api/controller/talk.controller.ts
+++ b/src/adapters/api/controller/talk.controller.ts
@@ -1,7 +1,12 @@
-import { Body, Controller, Param, Post } from '@nestjs/common';
+import { Body, Controller, Post, Param, UseGuards } from '@nestjs/common';
 import { CreateTalkCreationRequestUseCase } from '../../../core/usecases/create-talk-creation-request.use-case';
 import { ApproveOrRejectTalkUseCase } from '../../../core/usecases/approve-or-reject-talk-use.case';
 import { CreateTalkRequest } from '../request/create-talk.request';
+import { CreateTalkResponse } from '../response/create-talk.response';
+import { ApproveOrRejectTalkMapper } from '../mapper/approve-or-reject-talk.mapper';
+import { ApproveOrRejectTalkRequest } from '../request/approve-or-reject-talk.request';
+import { CreateTalkMapper } from '../mapper/create-talk.mapper';
+import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import {
   ApiBadRequestResponse,
   ApiConflictResponse,
@@ -10,12 +15,10 @@ import {
   ApiNoContentResponse,
   ApiNotFoundResponse,
   ApiOperation,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { CreateTalkResponse } from '../response/create-talk.response';
-import { ApproveOrRejectTalkMapper } from '../mapper/approve-or-reject-talk.mapper';
-import { ApproveOrRejectTalkRequest } from '../request/approve-or-reject-talk.request';
-import { CreateTalkMapper } from '../mapper/create-talk.mapper';
 
+@UseGuards(JwtAuthGuard)
 @Controller('/talks')
 export class TalkController {
   constructor(
@@ -43,6 +46,9 @@ export class TalkController {
   @ApiInternalServerErrorResponse({
     description: 'Internal server error',
   })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized access',
+  })
   async createTalk(
     @Body() body: CreateTalkRequest,
   ): Promise<CreateTalkResponse> {
@@ -65,6 +71,9 @@ export class TalkController {
   })
   @ApiInternalServerErrorResponse({
     description: 'Internal server error',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Unauthorized access',
   })
   async approveOrRejectTalk(
     @Param('talkId') talkId: string,

--- a/src/adapters/api/decorator/current-user.decorator.ts
+++ b/src/adapters/api/decorator/current-user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
+
+export const CurrentUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): unknown => {
+    const request = ctx
+      .switchToHttp()
+      .getRequest<Request & { user?: unknown }>();
+    return request.user;
+  },
+);

--- a/src/adapters/api/guards/jwt-auth.guard.ts
+++ b/src/adapters/api/guards/jwt-auth.guard.ts
@@ -1,0 +1,40 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { TokenService } from '../../../core/domain/service/token.service';
+import { ProfileRequest } from '../request/profile.request';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(
+    @Inject('TokenService') private readonly tokenService: TokenService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader: string | undefined = request.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    const token: string | undefined = authHeader.split(' ')[1];
+
+    if (!token) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    try {
+      const payload = this.tokenService.verifyToken(token) as ProfileRequest;
+      (request as Request & { user?: unknown }).user = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+}

--- a/src/adapters/api/mapper/profile.mapper.ts
+++ b/src/adapters/api/mapper/profile.mapper.ts
@@ -1,0 +1,10 @@
+import { ProfileRequest } from '../request/profile.request';
+
+export class ProfileMapper {
+  static fromDomain(user: ProfileRequest): ProfileRequest {
+    return {
+      id: user.id,
+      email: user.email,
+    };
+  }
+}

--- a/src/adapters/api/request/profile.request.ts
+++ b/src/adapters/api/request/profile.request.ts
@@ -1,0 +1,4 @@
+export type ProfileRequest = {
+  id: string;
+  email: string;
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { TokenService } from './core/domain/service/token.service';
 import { UserController } from './adapters/api/controller/auth.controller';
 import { UserRepository } from './core/domain/repository/user.repository';
 import { ApproveOrRejectTalkUseCase } from './core/usecases/approve-or-reject-talk-use.case';
+import { JwtAuthGuard } from './adapters/api/guards/jwt-auth.guard';
 
 @Module({
   imports: [JwtModule.register({})],
@@ -33,6 +34,7 @@ import { ApproveOrRejectTalkUseCase } from './core/usecases/approve-or-reject-ta
   providers: [
     PrismaService,
     JwtService,
+    JwtAuthGuard,
     {
       provide: 'TokenService',
       useFactory: (jwtService: JwtService) => new JwtServiceAdapter(jwtService),

--- a/src/core/usecases/__test__/login.use-case.spec.ts
+++ b/src/core/usecases/__test__/login.use-case.spec.ts
@@ -54,7 +54,7 @@ describe('LoginUseCase', () => {
     expect(result).toEqual('mocked-jwt-token');
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(tokenService.generateToken).toHaveBeenCalledWith({
-      userId: user.id,
+      id: user.id,
       email: user.email,
     });
   });

--- a/src/core/usecases/login.use-case.ts
+++ b/src/core/usecases/login.use-case.ts
@@ -29,7 +29,7 @@ export class LoginUseCase implements UseCase<LoginCommand, string> {
     }
 
     const token = this.tokenService.generateToken({
-      userId: user.id,
+      id: user.id,
       email: user.email,
     });
 


### PR DESCRIPTION
## Added
* Added a `JwtAuthGuard` to secure endpoints, ensuring only authenticated users can access certain routes (`auth.controller.ts`, `room.controller.ts`, `talk.controller.ts`). [[1]](diffhunk://#diff-4568253b9646addadd89d2c9e78e0de64f4ff019c0c93a74e4313745c6c8af40R33-R38) [[2]](diffhunk://#diff-7548f3bf7b0eb8a73fa273140e0b778677a10b5ee5746abbc6b6007429d3d23eL1-R9) [[3]](diffhunk://#diff-ed954031d74d740afc8a7d91b280066c65a540cdcace3eeb0d6006f8760dd4c0L1-R8) [[4]](diffhunk://#diff-2641b47d7465b6625c0998c99149ab62f4895a8148448b29e16fc740c02bd745R1-R40)
* Introduced the `CurrentUser` decorator to extract the authenticated user's information from the request for use in controllers (`current-user.decorator.ts`).

## New Features
* Added a `/me` endpoint in `UserController` to retrieve the authenticated user's profile using the `JwtAuthGuard` and `CurrentUser` decorator (`auth.controller.ts`).